### PR TITLE
Feat/tranches

### DIFF
--- a/contracts/TranchePricing.sol
+++ b/contracts/TranchePricing.sol
@@ -1,0 +1,147 @@
+pragma solidity ^0.4.6;
+
+import "./PricingStrategy.sol";
+import "./Crowdsale.sol";
+import "./SafeMathLib.sol";
+import "zeppelin/contracts/ownership/Ownable.sol";
+
+/// @dev Tranche based pricing with special support for pre-ico deals.
+contract TranchePricing is PricingStrategy, Ownable {
+
+  using SafeMathLib for uint;
+
+  uint public constant MAX_TRANCHES = 10;
+
+  // This contains all pre-ICO addresses, and their prices (weis per token)
+  mapping (address => uint) public preicoAddresses;
+
+  /**
+  * Define pricing schedule using tranches.
+  */
+  struct Tranche {
+
+      // Amount in weis when this tranche becomes active
+      uint amount;
+
+      // How many tokens per satoshi you will get while this tranche is active
+      uint price;
+  }
+
+  // Store tranches in a fixed array, so that it can be seen in a blockchain explorer
+  // Tranche 0 is always (0, 0)
+  // (TODO: change this when we confirm dynamic arrays are explorable)
+  Tranche[10] public tranches;
+
+  // How many active tranches we have
+  uint public trancheCount;
+
+  /// @dev Contruction, creating a list of tranches
+  /// @param _tranches uint[] tranches Pairs of (start amount, price)
+  function TranchePricing(uint[] _tranches) {
+    // Need to have tuples, length check
+    if(_tranches.length % 2 == 1 || _tranches.length >= MAX_TRANCHES*2) {
+      throw;
+    }
+
+    trancheCount = _tranches.length / 2;
+
+    uint highestAmount = 0;
+
+    for(uint i=0; i<_tranches.length/2; i++) {
+      tranches[i].amount = _tranches[i*2];
+      tranches[i].price = _tranches[i*2+1];
+
+      // No invalid steps
+      if((highestAmount != 0) && (tranches[i].amount <= highestAmount)) {
+        throw;
+      }
+
+      highestAmount = tranches[i].amount;
+    }
+
+    // Last tranche price must be zero, terminating the crowdale
+    if(tranches[trancheCount-1].price != 0) {
+      throw;
+    }
+  }
+
+  /// @dev This is invoked once for every pre-ICO address, set pricePerToken
+  ///      to 0 to disable
+  /// @param preicoAddress PresaleFundCollector address
+  /// @param pricePerToken How many weis one token cost for pre-ico investors
+  function setPreicoAddress(address preicoAddress, uint pricePerToken)
+    public
+    onlyOwner
+  {
+    preicoAddresses[preicoAddress] = pricePerToken;
+  }
+
+  /// @dev Iterate through tranches. You reach end of tranches when price = 0
+  /// @return tuple (time, price)
+  function getTranche(uint n) public constant returns (uint, uint) {
+    return (tranches[n].amount, tranches[n].price);
+  }
+
+  function getFirstTranche() private constant returns (Tranche) {
+    return tranches[0];
+  }
+
+  function getLastTranche() private constant returns (Tranche) {
+    return tranches[trancheCount-1];
+  }
+
+  function getPricingStartsAt() public constant returns (uint) {
+    return getFirstTranche().amount;
+  }
+
+  function getPricingEndsAt() public constant returns (uint) {
+    return getLastTranche().amount;
+  }
+
+  function isSane(address _crowdsale) public constant returns(bool) {
+    // Our tranches are not bound by time, so we can't really check are we sane
+    // so we presume we are ;)
+    // In the future we could save and track raised tokens, and compare it to
+    // the Crowdsale contract.
+    return true;
+  }
+
+  /// @dev Get the current tranche or bail out if we are not in the tranche periods.
+  /// @param tokensSold total amount of tokens sold, for calculating the current tranche
+  /// @return {[type]} [description]
+  function getCurrentTranche(uint tokensSold) private constant returns (Tranche) {
+    uint i;
+
+    for(i=0; i < tranches.length; i++) {
+      if(tokensSold < tranches[i].amount) {
+        return tranches[i-1];
+      }
+    }
+  }
+
+  /// @dev Get the current price.
+  /// @param tokensSold total amount of tokens sold, for calculating the current tranche
+  /// @return The current price or 0 if we are outside trache ranges
+  function getCurrentPrice(uint tokensSold) public constant returns (uint result) {
+    return getCurrentTranche(tokensSold).price;
+  }
+
+  /// @dev Calculate the current price for buy in amount.
+  function calculatePrice(uint value, uint tokensSold, uint weiRaised, address msgSender, uint decimals) public constant returns (uint) {
+
+    uint multiplier = 10 ** decimals;
+
+    // This investor is coming through pre-ico
+    if(preicoAddresses[msgSender] > 0) {
+      return value.times(multiplier) / preicoAddresses[msgSender];
+    }
+
+    uint price = getCurrentPrice(tokensSold);
+    return value.times(multiplier) / price;
+  }
+
+  function() payable {
+    throw; // No money on this contract
+  }
+
+}

--- a/ico/tests/contracts/test_tranche_pricing.py
+++ b/ico/tests/contracts/test_tranche_pricing.py
@@ -1,0 +1,287 @@
+"""Tranche based pricing"""
+import datetime
+
+import pytest
+from decimal import Decimal
+from eth_utils import to_wei
+from ethereum.tester import TransactionFailed
+from web3.contract import Contract
+
+
+from ico.tests.utils import time_travel
+from ico.state import CrowdsaleState
+from ico.utils import decimalize_token_amount
+
+
+@pytest.fixture
+def presale_fund_collector(chain, presale_freeze_ends_at, team_multisig) -> Contract:
+    """In actual ICO, the price is doubled (for testing purposes)."""
+
+    args = [
+        team_multisig,
+        presale_freeze_ends_at,
+        to_wei("50", "ether"),  # Minimum presale buy in is 50 ethers
+
+    ]
+    tx = {
+        "from": team_multisig,
+    }
+    presale_fund_collector, hash = chain.provider.deploy_contract('PresaleFundCollector', deploy_args=args, deploy_transaction=tx)
+    return presale_fund_collector
+
+
+@pytest.fixture
+def start_time() -> int:
+    return int((datetime.datetime(2017, 4, 15, 16, 00) - datetime.datetime(1970, 1, 1)).total_seconds())
+
+
+@pytest.fixture
+def end_time(start_time) -> int:
+    return int(start_time + 4*7*24*3600)
+
+
+@pytest.fixture
+def token(uncapped_token) -> Contract:
+    """Token contract used in tranche tests"""
+    return uncapped_token
+
+
+@pytest.fixture
+def fractional_token(chain, token_name, token_symbol, team_multisig) -> Contract:
+    """Token contract having 8 decimal places."""
+
+    args = [token_name, token_symbol, 0, 8]  # Owner set
+
+    tx = {
+        "from": team_multisig
+    }
+
+    contract, hash = chain.provider.deploy_contract('CrowdsaleToken', deploy_args=args, deploy_transaction=tx)
+    return contract
+
+
+@pytest.fixture
+def tranche_pricing(chain, presale_fund_collector, start_time, end_time, team_multisig):
+
+    week = 24*3600*7
+
+    args = [
+        [
+            0, to_wei("0.10", "ether"),
+            123, to_wei("0.12", "ether"),
+            1234, to_wei("0.13", "ether"),
+            12345, to_wei("0.14", "ether"),
+            123456, to_wei("0", "ether"),
+        ],
+    ]
+
+    tx = {
+        "gas": 4000000,
+        "from": team_multisig
+    }
+    contract, hash = chain.provider.deploy_contract('TranchePricing', deploy_args=args, deploy_transaction=tx)
+
+    contract.transact({"from": team_multisig}).setPreicoAddress(presale_fund_collector.address, to_wei("0.05", "ether"))
+    return contract
+
+
+@pytest.fixture
+def tranche_ico(chain, team_multisig, start_time, tranche_pricing, preico_cap, preico_funding_goal, token, presale_fund_collector, end_time) -> Contract:
+    """Create a crowdsale contract that uses tranche based pricing."""
+
+    args = [
+        token.address,
+        tranche_pricing.address,
+        team_multisig,
+        start_time,
+        end_time,
+        0,
+    ]
+
+    tx = {
+        "from": team_multisig,
+    }
+
+    contract, hash = chain.provider.deploy_contract('UncappedCrowdsale', deploy_args=args, deploy_transaction=tx)
+
+    assert contract.call().owner() == team_multisig
+    assert not token.call().released()
+
+    # Allow crowdsale contract to do mint()
+    token.transact({"from": team_multisig}).setMintAgent(contract.address, True)
+    assert token.call().mintAgents(contract.address) == True
+
+    return contract
+
+
+@pytest.fixture()
+def finalizer(chain, token, tranche_ico, team_multisig) -> Contract:
+    """Set crowdsale end strategy."""
+
+    # Create finalizer contract
+    args = [
+        token.address,
+        tranche_ico.address,
+    ]
+    contract, hash = chain.provider.deploy_contract('DefaultFinalizeAgent', deploy_args=args)
+
+    token.transact({"from": team_multisig}).setReleaseAgent(contract.address)
+    tranche_ico.transact({"from": team_multisig}).setFinalizeAgent(contract.address)
+    return contract
+
+
+def test_tranche_getter(chain, tranche_pricing, start_time):
+    """Tranche data is exposed to the world."""
+
+    amount, price = tranche_pricing.call().getTranche(0)
+    assert amount == 0 #Tranche amount
+    assert price == 100000000000000000
+
+
+def test_tranche_data(chain, tranche_pricing, start_time):
+    """Tranche data can be read."""
+
+    for i in range(0, 4):
+        time, price = tranche_pricing.call().getTranche(i)
+        print("-", time)
+        print("-", price)
+
+
+def test_tranche_prices(chain, tranche_pricing, start_time, end_time, customer):
+    """We get correct tranche prices for different dates."""
+
+    #TODO: Instead of timetravel, buy tokens here after this line, and then copy this
+    assert tranche_pricing.call().calculatePrice(
+        to_wei("0.10", "ether"),
+        0,
+        0,
+        customer,
+        0,
+    ) == 1
+
+    assert tranche_pricing.call().calculatePrice(
+        to_wei("0.10", "ether"),
+        122,
+        0,
+        customer,
+        0,
+    ) == 1
+
+    assert tranche_pricing.call().calculatePrice(
+        to_wei("0.12", "ether"),
+        123,
+        0,
+        customer,
+        0,
+    ) == 1
+
+
+def test_non_fractional_price(chain, tranche_pricing, customer, end_time):
+    """We divide price correctly for integer only amount."""
+
+    assert tranche_pricing.call().calculatePrice(
+        to_wei("0.28", "ether"),
+        0,
+        0,
+        customer,
+        0,
+    ) == 2
+
+    assert tranche_pricing.call().calculatePrice(
+        to_wei("0.281", "ether"),
+        0,
+        0,
+        customer,
+        0,
+    ) == 2
+
+    assert tranche_pricing.call().calculatePrice(
+        to_wei("0.11", "ether"),
+        122,
+        0,
+        customer,
+        0,
+    ) == 1
+
+    assert tranche_pricing.call().calculatePrice(
+        to_wei("0.25", "ether"),
+        123,
+        0,
+        customer,
+        0,
+    ) == 2
+
+
+def test_tranche_calculate_preico_price(chain, tranche_pricing, start_time, presale_fund_collector):
+    """Preico contributors get their special price."""
+
+    # Pre-ico address always buys at the fixed price
+    assert tranche_pricing.call().calculatePrice(
+        to_wei("0.05", "ether"),
+        0,
+        0,
+        presale_fund_collector.address,
+        0
+    ) == 1
+
+
+def test_presale_move_to_tranche_based_crowdsale(chain, presale_fund_collector, tranche_ico, finalizer, token, start_time, team_multisig, customer, customer_2):
+    """When pre-ico contract funds are moved to the crowdsale, the pre-sale investors gets tokens with a preferred price and not the current tranche price."""
+
+    value = to_wei(50, "ether")
+    presale_fund_collector.transact({"from": customer, "value": value}).invest()
+
+    # ICO begins, Link presale to an actual ICO
+    presale_fund_collector.transact({"from": team_multisig}).setCrowdsale(tranche_ico.address)
+    time_travel(chain, start_time)
+
+    assert tranche_ico.call().getState() == CrowdsaleState.Funding
+
+    # Load funds to ICO
+    presale_fund_collector.transact().parcipateCrowdsaleAll()
+
+    # Tokens received, paid by preico price
+    tranche_ico.call().investedAmountOf(customer) == to_wei(50, "ether")
+    token.call().balanceOf(customer) == 50 / 0.050
+
+
+def test_fractional_preico_pricing(presale_fund_collector, tranche_pricing, fractional_token):
+    """Pre-ICO amount is calculated correctly for a token having fractions.
+
+    """
+
+    amount = tranche_pricing.call().calculatePrice(
+        to_wei("0.05", "ether"),
+        0,
+        0,
+        presale_fund_collector.address,
+        fractional_token.call().decimals()
+    )
+
+    assert amount == 100000000
+    d = decimalize_token_amount(fractional_token, amount)
+
+    assert d == 1
+
+    # Make sure we get decimals right
+    assert d.as_tuple() == Decimal("1.00000000").as_tuple()
+
+
+def test_fractional_tranche_pricing(chain, presale_fund_collector, tranche_pricing, fractional_token, customer):
+    """Tranche amount is calculated correctly for a token having fractions."""
+
+    amount = tranche_pricing.call().calculatePrice(
+        to_wei("0.512345678", "ether"),
+        0,
+        0,
+        customer,
+        fractional_token.call().decimals()
+    )
+
+    assert amount == 512345678
+    d = decimalize_token_amount(fractional_token, amount)
+
+    assert d == Decimal("5.12345678")
+
+    # Make sure we get decimals right
+    assert d.as_tuple() == Decimal("5.12345678").as_tuple()


### PR DESCRIPTION
TranchePricing: Adding a base for TranchePricing

Basic tranche handling done, calculatePrice() is now passing the tokensSold
all the way to the final getCurrentTranche(uint) function.

The isSane() is a difficult case, since in the original MilestonePricing
contract which is used as a base for this TranchePricing, "sanefulness" is
measured by comparing our start and end times to the ones in Crowdsale.
However, since we don't have any information to compare with the Crowdsale
contract, returning always "true" for now.

Tests: Added tests for the TranchePricing contract

Handling basic testcases considering the tranches feature.

Unit-test.yml not changed, since it seems to test MilestonePricing
as the pricing_strategy, and not pricing strategies in general.