### PR TITLE
CrowdsaleToken: added setTokenInformation(string name, string symbol)…

### DIFF
--- a/contracts/CrowdsaleToken.sol
+++ b/contracts/CrowdsaleToken.sol
@@ -20,6 +20,8 @@ import "./SafeMathLib.sol";
  */
 contract CrowdsaleToken is ReleasableToken, MintableToken, UpgradeableToken {
 
+  event UpdatedTokenInformation(string newName, string newSymbol);
+
   string public name;
 
   string public symbol;
@@ -81,6 +83,16 @@ contract CrowdsaleToken is ReleasableToken, MintableToken, UpgradeableToken {
    */
   function canUpgrade() public constant returns(bool) {
     return released && super.canUpgrade();
+  }
+
+  /**
+   * Owner can update token information here
+   */
+  function setTokenInformation(string _name, string _symbol) onlyOwner {
+    name = _name;
+    symbol = _symbol;
+
+    UpdatedTokenInformation(name, symbol);
   }
 
 }

--- a/ico/tests/contracts/test_token.py
+++ b/ico/tests/contracts/test_token.py
@@ -4,6 +4,13 @@ import pytest
 from ethereum.tester import TransactionFailed
 from web3.contract import Contract
 
+@pytest.fixture
+def token_new_name() -> str:
+    return "New name"
+
+@pytest.fixture
+def token_new_symbol() -> str:
+    return "NEW"
 
 def test_token_initialized(token: Contract, team_multisig: str, token_symbol: str, token_name: str, initial_supply: int):
     """Token is initialized with the parameters we want."""
@@ -18,3 +25,11 @@ def test_malicious_transfer_agent_set(token: Contract, malicious_address):
 
     with pytest.raises(TransactionFailed):
         token.transact({"from": malicious_address}).setTransferAgent(malicious_address, True)
+
+def test_token_rename(token: Contract, team_multisig, token_new_name, token_new_symbol):
+    """We will update token's information here"""
+
+    token.transact({"from": team_multisig}).setTokenInformation(token_new_name, token_new_symbol)
+
+    assert token.call().name() == token_new_name
+    assert token.call().symbol() == token_new_symbol


### PR DESCRIPTION
… onlyOwner

Added a new function to modify token information: the name and the symbol of
the token.

CrowdsaleToken was chosen because it was the only common level where Ownable is
defined for sure (StandardToken would have been selected otherwise).