### PR TITLE
Sleep before etherscan source verification and post-deployment verification

### DIFF
--- a/ico/deploy.py
+++ b/ico/deploy.py
@@ -5,6 +5,7 @@ from collections import Counter
 from collections import defaultdict
 from typing import Tuple
 import os
+import time
 
 import jinja2
 import ruamel.yaml
@@ -218,6 +219,10 @@ def perform_verify_actions(chain, runtime_data: dict, contracts: dict):
 
         verify_actions = textwrap.dedent(verify_actions)
         print("Performing deployment verification")
+
+        # Allow some time for post_actions to be mined
+        time.sleep(60)
+
         exec_lines(verify_actions, context, print_prefix="Verification:")
     else:
         print("No verify defined")

--- a/ico/etherscan.py
+++ b/ico/etherscan.py
@@ -70,6 +70,9 @@ def verify_contract(project: Project, chain_name: str, address: str, contract_na
             browser.fill("ctl00$ContentPlaceHolder1$txtLibraryName{}".format(idx), library_name)
             idx += 1
 
+        # Give the contract deployment some time to propagate so that Etherscan will find it
+        time.sleep(30)
+
         browser.find_by_name("ctl00$ContentPlaceHolder1$btnSubmit").click()
 
         deadline = time.time() + 60


### PR DESCRIPTION
When adding source verification, Etherscan will not find the contract if trying soon after the contract's deployment. Similarly, post-deployment asserts may not hold true soon after deployment and post_actions.

The quick fix here is to add some sleeps before the operations. Feel free to reject this PR if you feel the timeouts are too hacky. A much better solution would be to keep trying again until success or timeout, and/or wait until all pending transactions are mined (and then some).