### PR TITLE
requirements: Upgraded py-solc to support newer solc

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -84,4 +84,17 @@ Then install ``ico`` Python package and its dependencies:
     pip install -r requirements.txt
     pip install -e .
 
+Using your desired Solc version
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Sometimes it's useful to use some certain version of the Solidity compiler,
+this can be done using py-solc package, like this:
 
+.. code-block:: console
+    python -m solc.install v0.4.16
+
+If you are lucky, you can now run binary ~/.py-solc/solc-v0.4.16/bin/solc.
+The binary is not available every platform.
+Remember to update your PATH accordingly:
+
+.. code-block:: console
+    export PATH=/home/YOURNAME/.py-solc/solc-v0.4.16/bin:$PATH

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pbkdf2==1.3
 populus==1.9.0
 py==1.4.34
 py-geth==1.9.0
-py-solc==1.2.2
+py-solc==1.4.0
 pycparser==2.18
 pycryptodome==3.4.6
 pyethash==0.1.27


### PR DESCRIPTION
Now you can update your local Solidity compiler to 0.4.16 with:
python -m solc.install v0.4.16
Remember to adjust your path to point ~/.py-solc/solc-v0.4.16/bin.