### PR TITLE
CentrallyIssuedToken: Permitting token information change more than once

### DIFF
--- a/contracts/CentrallyIssuedToken.sol
+++ b/contracts/CentrallyIssuedToken.sol
@@ -58,12 +58,6 @@ contract CentrallyIssuedToken is BurnableToken, UpgradeableToken {
       throw;
     }
 
-    if(bytes(name).length > 0 || bytes(symbol).length > 0) {
-      // Information already set
-      // Allow owner to set this information only once
-      throw;
-    }
-
     name = _name;
     symbol = _symbol;
     UpdatedTokenInformation(name, symbol);


### PR DESCRIPTION
The limitation of setting token information once is an old relic.
Token information change have been important in the past, and will be in
the future. Investor protection is not affected, since vital data is not
changed: only token name and symbol.