### PR TITLE
Zeppelin: Update to OpenZeppelin contracts to 7586e38

### DIFF
--- a/contracts/BurnableToken.sol
+++ b/contracts/BurnableToken.sol
@@ -23,7 +23,7 @@ contract BurnableToken is StandardTokenExt {
   function burn(uint burnAmount) {
     address burner = msg.sender;
     balances[burner] = balances[burner].sub(burnAmount);
-    totalSupply = totalSupply.sub(burnAmount);
+    totalSupply_ = totalSupply_.sub(burnAmount);
     Burned(burner, burnAmount);
 
     // Inform the blockchain explores that track the

--- a/contracts/CentrallyIssuedToken.sol
+++ b/contracts/CentrallyIssuedToken.sol
@@ -33,7 +33,7 @@ contract CentrallyIssuedToken is BurnableToken, UpgradeableToken {
   function CentrallyIssuedToken(address _owner, string _name, string _symbol, uint _totalSupply, uint _decimals, uint _releaseFinalizationDate)  UpgradeableToken(_owner) {
     name = _name;
     symbol = _symbol;
-    totalSupply = _totalSupply;
+    totalSupply_ = _totalSupply;
     decimals = _decimals;
 
     // Allocate initial balance to the owner

--- a/contracts/CrowdsaleToken.sol
+++ b/contracts/CrowdsaleToken.sol
@@ -55,21 +55,21 @@ contract CrowdsaleToken is ReleasableToken, MintableToken, UpgradeableToken {
     name = _name;
     symbol = _symbol;
 
-    totalSupply = _initialSupply;
+    totalSupply_ = _initialSupply;
 
     decimals = _decimals;
 
     // Create initially all balance on the team multisig
-    balances[owner] = totalSupply;
+    balances[owner] = totalSupply_;
 
-    if(totalSupply > 0) {
-      Minted(owner, totalSupply);
+    if(totalSupply_ > 0) {
+      Minted(owner, totalSupply_);
     }
 
     // No more new supply allowed after the token creation
     if(!_mintable) {
       mintingFinished = true;
-      if(totalSupply == 0) {
+      if(totalSupply_ == 0) {
         throw; // Cannot create a token without supply and no minting
       }
     }

--- a/contracts/FractionalERC20.sol
+++ b/contracts/FractionalERC20.sol
@@ -6,7 +6,7 @@
 
 pragma solidity ^0.4.8;
 
-import "zeppelin/contracts/token/ERC20.sol";
+import "zeppelin/contracts/token/ERC20/ERC20.sol";
 
 /**
  * A token that defines fractional units as decimals.

--- a/contracts/MintableToken.sol
+++ b/contracts/MintableToken.sol
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, version 2.0: https://github.com/TokenMarketNet/ico/blob/master/LICENSE.txt
  */
 
-import "zeppelin/contracts/token/ERC20.sol";
+import "zeppelin/contracts/token/ERC20/ERC20.sol";
 import "./StandardTokenExt.sol";
 import "./SafeMathLib.sol";
 
@@ -35,7 +35,7 @@ contract MintableToken is StandardTokenExt {
    * Only callably by a crowdsale contract (mint agent).
    */
   function mint(address receiver, uint amount) onlyMintAgent canMint public {
-    totalSupply = totalSupply.plus(amount);
+    totalSupply_ = totalSupply_.plus(amount);
     balances[receiver] = balances[receiver].plus(amount);
 
     // This will make the mint transaction apper in EtherScan.io

--- a/contracts/Recoverable.sol
+++ b/contracts/Recoverable.sol
@@ -7,7 +7,7 @@
 pragma solidity ^0.4.12;
 
 import "zeppelin/contracts/ownership/Ownable.sol";
-import "zeppelin/contracts/token/ERC20Basic.sol";
+import "zeppelin/contracts/token/ERC20/ERC20Basic.sol";
 
 contract Recoverable is Ownable {
 

--- a/contracts/StandardTokenExt.sol
+++ b/contracts/StandardTokenExt.sol
@@ -6,7 +6,7 @@
 
 pragma solidity ^0.4.14;
 
-import "zeppelin/contracts/token/StandardToken.sol";
+import "zeppelin/contracts/token/ERC20/StandardToken.sol";
 import "./Recoverable.sol";
 
 
@@ -16,7 +16,7 @@ import "./Recoverable.sol";
  * @notice Interface marker is used by crowdsale contracts to validate that addresses point a good token contract.
  *
  */
-contract StandardTokenExt is Recoverable, StandardToken {
+contract StandardTokenExt is StandardToken, Recoverable {
 
   /* Interface declaration */
   function isToken() public constant returns (bool weAre) {

--- a/contracts/UpgradeableToken.sol
+++ b/contracts/UpgradeableToken.sol
@@ -6,7 +6,7 @@
 
 pragma solidity ^0.4.8;
 
-import "zeppelin/contracts/token/ERC20.sol";
+import "zeppelin/contracts/token/ERC20/ERC20.sol";
 import "./StandardTokenExt.sol";
 import "./UpgradeAgent.sol";
 
@@ -71,7 +71,7 @@ contract UpgradeableToken is StandardTokenExt {
       balances[msg.sender] = balances[msg.sender].sub(value);
 
       // Take tokens out from circulation
-      totalSupply = totalSupply.sub(value);
+      totalSupply_ = totalSupply_.sub(value);
       totalUpgraded = totalUpgraded.add(value);
 
       // Upgrade agent reissues the tokens
@@ -100,7 +100,7 @@ contract UpgradeableToken is StandardTokenExt {
       // Bad interface
       if(!upgradeAgent.isUpgradeAgent()) throw;
       // Make sure that token supplies match in source and target
-      if (upgradeAgent.originalSupply() != totalSupply) throw;
+      if (upgradeAgent.originalSupply() != totalSupply_) throw;
 
       UpgradeAgentSet(upgradeAgent);
   }

--- a/contracts/test/TestMigrationTarget.sol
+++ b/contracts/test/TestMigrationTarget.sol
@@ -37,7 +37,7 @@ contract TestMigrationTarget is StandardTokenExt, UpgradeAgent {
     if (msg.sender != address(oldToken)) throw; // only upgrade from oldToken
 
     // Mint new tokens to the migrator
-    totalSupply = totalSupply.plus(_value);
+    totalSupply_ = totalSupply_.plus(_value);
     balances[_from] = balances[_from].plus(_value);
     Transfer(0, _from, _value);
   }


### PR DESCRIPTION
This commit updates OpenZeppelin, including the following integration work:
    * Replaced paths
    * Using totalSupply_ instead of totalSupply