### PR TITLE
[WIP] Made ico compatible with the latest version of populus and solidity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 sudo: true
 
 env:
-  - TOXENV=py35 SOLC_VERSION=0.4.18
+  - TOXENV=py35 SOLC_VERSION=0.4.24
 
 cache:
   - pip: true

--- a/crowdsales/example.yml
+++ b/crowdsales/example.yml
@@ -185,9 +185,9 @@ testnet:
     # Make sure that everything we have deployed all contracts in good state
     # and their internal state is sane
     verify_actions: |
-        assert token.call().owner() == team_multisig.address
-        assert crowdsale.call().owner() == team_multisig.address
-        assert preico.call().owner() == team_multisig.address
-        assert finalize_agent.call().teamMultisig() == team_multisig.address
+        assert token.call().owner() == web3.toChecksumAddress(team_multisig.address)
+        assert crowdsale.call().owner() == web3.toChecksumAddress(team_multisig.address)
+        assert preico.call().owner() == web3.toChecksumAddress(team_multisig.address)
+        assert finalize_agent.call().teamMultisig() == web3.toChecksumAddress(team_multisig.address)
         assert finalize_agent.call().isSane()
         assert crowdsale.call().getState() == CrowdsaleState.PreFunding

--- a/crowdsales/unit-test.yml
+++ b/crowdsales/unit-test.yml
@@ -187,12 +187,12 @@ unit_test:
     # Make sure that everything we have deployed all contracts in good state
     # and their internal state is sane
     verify_actions: |
-        assert token.call().owner() == team_multisig.address, "Expected owner {}, got {}".format(token.call().owner(),team_multisig.address)
-        assert crowdsale.call().owner() == team_multisig.address
-        assert preico.call().owner() == team_multisig.address
-        assert token.call().owner() == team_multisig.address
-        assert token.call().upgradeMaster() == team_multisig.address
-        assert finalize_agent.call().teamMultisig() == team_multisig.address
+        assert token.call().owner() == web3.toChecksumAddress(team_multisig.address), "Expected owner {}, got {}".format(token.call().owner(),team_multisig.address)
+        assert crowdsale.call().owner() == web3.toChecksumAddress(team_multisig.address)
+        assert preico.call().owner() == web3.toChecksumAddress(team_multisig.address)
+        assert token.call().owner() == web3.toChecksumAddress(team_multisig.address)
+        assert token.call().upgradeMaster() == web3.toChecksumAddress(team_multisig.address)
+        assert finalize_agent.call().teamMultisig() == web3.toChecksumAddress(team_multisig.address)
         assert finalize_agent.call().isSane()
         assert crowdsale.call().getState() == CrowdsaleState.PreFunding
 

--- a/ico/tests/contracts/test_eth_tranche_pricing.py
+++ b/ico/tests/contracts/test_eth_tranche_pricing.py
@@ -318,7 +318,7 @@ def test_presale_update_counters(chain, presale_fund_collector, wei_tranche_ico,
     """
 
     # We have set up the contracts in the way the presale purchaser gets special pricing
-    assert wei_tranche_ico.call().pricingStrategy() == wei_tranche_pricing.address
+    assert wei_tranche_ico.call().pricingStrategy() == chain.web3.toChecksumAddress(wei_tranche_pricing.address)
     wei_tranche_pricing.transact({"from": team_multisig}).setPreicoAddress(customer, to_wei("0.05", "ether"))
 
     assert wei_tranche_pricing.call().isPresalePurchase(customer) == True

--- a/ico/tests/contracts/test_finalize.py
+++ b/ico/tests/contracts/test_finalize.py
@@ -34,7 +34,8 @@ def test_finalize_success(chain: TestRPCChain, uncapped_flatprice_final: Contrac
 
     time_travel(chain, preico_ends_at + 1)
     assert uncapped_flatprice_final.call().getState() == CrowdsaleState.Success
-    assert uncapped_flatprice_final.call().finalizeAgent() == default_finalize_agent.address
+    assert uncapped_flatprice_final.call().finalizeAgent() == chain.web3.toChecksumAddress(
+        default_finalize_agent.address)
 
     # Release the tokens
     uncapped_flatprice_final.transact({"from": team_multisig}).finalize()

--- a/ico/tests/contracts/test_issuer.py
+++ b/ico/tests/contracts/test_issuer.py
@@ -23,9 +23,9 @@ def token(chain, team_multisig) -> Contract:
 
 
 @pytest.fixture
-def issue_script_owner(accounts):
+def issue_script_owner(web3,  accounts):
     """Ethereum account that interacts with issuer contract."""
-    return accounts[8]
+    return web3.toChecksumAddress(accounts[8])
 
 
 @pytest.fixture

--- a/ico/tests/contracts/test_issuer_with_id.py
+++ b/ico/tests/contracts/test_issuer_with_id.py
@@ -30,9 +30,9 @@ def issuer_id_2() -> int:
     return int(2)
 
 @pytest.fixture
-def issue_script_owner(accounts):
+def issue_script_owner(web3, accounts):
     """Ethereum account that interacts with issuer contract."""
-    return accounts[8]
+    return web3.toChecksumAddress(accounts[8])
 
 
 @pytest.fixture

--- a/ico/tests/contracts/test_preico_proxy_buy.py
+++ b/ico/tests/contracts/test_preico_proxy_buy.py
@@ -131,7 +131,7 @@ def test_proxy_buy(chain, web3, customer, customer_2, team_multisig, proxy_buyer
     # Move over
     assert crowdsale.call().getState() == CrowdsaleState.Funding
     proxy_buyer.transact({"from": customer_2}).setCrowdsale(crowdsale.address)
-    assert proxy_buyer.call().crowdsale() == crowdsale.address
+    assert proxy_buyer.call().crowdsale() == web3.toChecksumAddress(crowdsale.address)
     proxy_buyer.transact({"from": customer}).buyForEverybody()
     assert web3.eth.getBalance(proxy_buyer.address) == 0
 
@@ -185,7 +185,7 @@ def test_proxy_buy_claim_twice(chain, web3, customer, customer_2, team_multisig,
     # Move over
     assert crowdsale.call().getState() == CrowdsaleState.Funding
     proxy_buyer.transact({"from": team_multisig}).setCrowdsale(crowdsale.address)
-    assert proxy_buyer.call().crowdsale() == crowdsale.address
+    assert proxy_buyer.call().crowdsale() == web3.toChecksumAddress(crowdsale.address)
     proxy_buyer.transact({"from": customer}).buyForEverybody()
 
     # We got our tokens
@@ -263,7 +263,7 @@ def test_proxy_buy_load_refund(chain, web3, customer, customer_2, team_multisig,
     # Move over
     assert crowdsale.call().getState() == CrowdsaleState.Funding
     proxy_buyer.transact({"from": team_multisig}).setCrowdsale(crowdsale.address)
-    assert proxy_buyer.call().crowdsale() == crowdsale.address
+    assert proxy_buyer.call().crowdsale() == web3.toChecksumAddress(crowdsale.address)
     proxy_buyer.transact({"from": customer}).buyForEverybody()
 
     proxy_buyer.transact({"from": team_multisig}).forceRefund()
@@ -293,7 +293,7 @@ def test_proxy_buy_move_funds_twice(chain, web3, customer, customer_2, team_mult
     # Move over
     assert crowdsale.call().getState() == CrowdsaleState.Funding
     proxy_buyer.transact({"from": team_multisig}).setCrowdsale(crowdsale.address)
-    assert proxy_buyer.call().crowdsale() == crowdsale.address
+    assert proxy_buyer.call().crowdsale() == web3.toChecksumAddress(crowdsale.address)
     proxy_buyer.transact({"from": customer}).buyForEverybody()
 
     with pytest.raises(TransactionFailed):
@@ -311,7 +311,7 @@ def test_proxy_buy_claim_too_much(chain, web3, customer, customer_2, team_multis
     # Move over
     assert crowdsale.call().getState() == CrowdsaleState.Funding
     proxy_buyer.transact({"from": team_multisig}).setCrowdsale(crowdsale.address)
-    assert proxy_buyer.call().crowdsale() == crowdsale.address
+    assert proxy_buyer.call().crowdsale() == web3.toChecksumAddress(crowdsale.address)
     proxy_buyer.transact({"from": customer}).buyForEverybody()
 
     # We got our tokens
@@ -377,7 +377,7 @@ def test_proxy_buyforeverybody_halted(chain, web3, customer, customer_2, team_mu
     # Move over
     assert crowdsale.call().getState() == CrowdsaleState.Funding
     proxy_buyer.transact({"from": team_multisig}).setCrowdsale(crowdsale.address)
-    assert proxy_buyer.call().crowdsale() == crowdsale.address
+    assert proxy_buyer.call().crowdsale() == web3.toChecksumAddress(crowdsale.address)
     proxy_buyer.transact({"from": team_multisig}).halt()
     with pytest.raises(TransactionFailed):
         proxy_buyer.transact({"from": customer}).buyForEverybody()
@@ -394,7 +394,7 @@ def test_proxy_buyforeverybody_halted_owner(chain, web3, customer, customer_2, t
     # Move over
     assert crowdsale.call().getState() == CrowdsaleState.Funding
     proxy_buyer.transact({"from": team_multisig}).setCrowdsale(crowdsale.address)
-    assert proxy_buyer.call().crowdsale() == crowdsale.address
+    assert proxy_buyer.call().crowdsale() == web3.toChecksumAddress(crowdsale.address)
     proxy_buyer.transact({"from": team_multisig}).halt()
     proxy_buyer.transact({"from": team_multisig}).buyForEverybody()
 
@@ -407,7 +407,7 @@ def test_proxy_buy_presale_pricing(chain, proxy_buyer, tranche_crowdsale, finali
     """
 
     # We have set up the contracts in the way the presale purchaser gets special pricing
-    assert tranche_crowdsale.call().pricingStrategy() == tranche_pricing.address
+    assert tranche_crowdsale.call().pricingStrategy() == chain.web3.toChecksumAddress(tranche_pricing.address)
     assert tranche_pricing.call().isPresalePurchase(proxy_buyer.address) == True
 
     value = to_wei(20000, "ether")
@@ -472,7 +472,7 @@ def test_proxy_timelock(chain, web3, customer, customer_2, team_multisig, proxy_
     # Move over
     assert crowdsale.call().getState() == CrowdsaleState.Funding
     proxy_buyer.transact({"from": customer_2}).setCrowdsale(crowdsale.address)
-    assert proxy_buyer.call().crowdsale() == crowdsale.address
+    assert proxy_buyer.call().crowdsale() == web3.toChecksumAddress(crowdsale.address)
     proxy_buyer.transact({"from": customer}).buyForEverybody()
     assert web3.eth.getBalance(proxy_buyer.address) == 0
 
@@ -529,7 +529,7 @@ def test_proxy_timelock_early(chain, web3, customer, customer_2, team_multisig, 
     # Move over
     assert crowdsale.call().getState() == CrowdsaleState.Funding
     proxy_buyer.transact({"from": customer_2}).setCrowdsale(crowdsale.address)
-    assert proxy_buyer.call().crowdsale() == crowdsale.address
+    assert proxy_buyer.call().crowdsale() == web3.toChecksumAddress(crowdsale.address)
     proxy_buyer.transact({"from": customer}).buyForEverybody()
     assert web3.eth.getBalance(proxy_buyer.address) == 0
 

--- a/ico/tests/contracts/test_uncapped_flatprice.py
+++ b/ico/tests/contracts/test_uncapped_flatprice.py
@@ -344,7 +344,7 @@ def test_close_early(chain: TestRPCChain, ico: Contract, customer: str, preico_s
     pricing_strategy, hash = chain.provider.deploy_contract('FlatPricing', deploy_args=args, deploy_transaction=tx)
 
     ico.transact({"from": team_multisig}).setPricingStrategy(pricing_strategy.address)
-    assert ico.call().pricingStrategy() == pricing_strategy.address
+    assert ico.call().pricingStrategy() == chain.web3.toChecksumAddress(pricing_strategy.address)
 
     ico.transact({"from": customer, "value": 1}).buy()
 

--- a/ico/tests/contracts/test_upgrade.py
+++ b/ico/tests/contracts/test_upgrade.py
@@ -2,6 +2,7 @@
 
 import pytest
 from ethereum.tester import TransactionFailed
+from populus.chain import TestRPCChain
 from web3.contract import Contract
 
 from ico.state import UpgradeState
@@ -40,14 +41,14 @@ def test_can_upgrade_released_token(released_token: Contract):
     assert released_token.call().getUpgradeState() == UpgradeState.WaitingForAgent
 
 
-def test_set_upgrade_agent(released_token: Contract, upgrade_agent: Contract, team_multisig):
+def test_set_upgrade_agent(chain: TestRPCChain, released_token: Contract, upgrade_agent: Contract, team_multisig):
     """Upgrade agent can be set on a released token."""
 
     # Preconditions are met
     assert upgrade_agent.call().isUpgradeAgent()
     assert released_token.call().canUpgrade()
     assert released_token.call().upgradeMaster() == team_multisig
-    assert upgrade_agent.call().oldToken() == released_token.address
+    assert upgrade_agent.call().oldToken() == chain.web3.toChecksumAddress(released_token.address)
     assert upgrade_agent.call().originalSupply() == released_token.call().totalSupply()
 
     released_token.transact({"from": team_multisig}).setUpgradeAgent(upgrade_agent.address)

--- a/ico/tests/fixtures/flatprice.py
+++ b/ico/tests/fixtures/flatprice.py
@@ -76,7 +76,6 @@ def uncapped_flatprice(chain, team_multisig, preico_starts_at, preico_ends_at, f
 
     tx = {
         "from": team_multisig,
-        "gas": 6000000,
     }
 
     contract, hash = chain.provider.deploy_contract('UncappedCrowdsale', deploy_args=args, deploy_transaction=tx)

--- a/ico/tests/fixtures/flatprice.py
+++ b/ico/tests/fixtures/flatprice.py
@@ -76,6 +76,7 @@ def uncapped_flatprice(chain, team_multisig, preico_starts_at, preico_ends_at, f
 
     tx = {
         "from": team_multisig,
+        "gas": 6000000,
     }
 
     contract, hash = chain.provider.deploy_contract('UncappedCrowdsale', deploy_args=args, deploy_transaction=tx)

--- a/ico/tests/fixtures/general.py
+++ b/ico/tests/fixtures/general.py
@@ -18,45 +18,45 @@ def initial_supply() -> str:
 
 
 @pytest.fixture
-def customer(accounts) -> str:
+def customer(web3, accounts) -> str:
     """Get a customer address."""
-    return accounts[1]
+    return web3.toChecksumAddress(accounts[1])
 
 
 @pytest.fixture
-def customer_2(accounts) -> str:
+def customer_2(web3, accounts) -> str:
     """Get another customer address."""
-    return accounts[2]
+    return web3.toChecksumAddress(accounts[2])
 
 
 @pytest.fixture
-def beneficiary(accounts) -> str:
+def beneficiary(web3, accounts) -> str:
     """The team control address."""
-    return accounts[3]
+    return web3.toChecksumAddress(accounts[3])
 
 
 @pytest.fixture
-def team_multisig(accounts) -> str:
+def team_multisig(web3, accounts) -> str:
     """The team multisig address."""
-    return accounts[4]
+    return web3.toChecksumAddress(accounts[4])
 
 
 @pytest.fixture
-def malicious_address(accounts) -> str:
+def malicious_address(web3, accounts) -> str:
     """Somebody who tries to perform activities they are not allowed to."""
-    return accounts[5]
+    return web3.toChecksumAddress(accounts[5])
 
 
 @pytest.fixture
-def empty_address(accounts):
+def empty_address(web3, accounts):
     """This account never holds anything."""
-    return accounts[6]
+    return web3.toChecksumAddress(accounts[6])
 
 
 @pytest.fixture
-def allowed_party(accounts):
+def allowed_party(web3, accounts):
     """Gets ERC-20 allowance."""
-    return accounts[7]
+    return web3.toChecksumAddress(accounts[7])
 
 
 

--- a/ico/tests/fixtures/presale.py
+++ b/ico/tests/fixtures/presale.py
@@ -52,6 +52,7 @@ def presale_fund_collector(chain, presale_freeze_ends_at, team_multisig) -> Cont
     ]
     tx = {
         "from": team_multisig,
+        "gas": 4000000
     }
     presale_fund_collector, hash = chain.provider.deploy_contract('PresaleFundCollector', deploy_args=args, deploy_transaction=tx)
     return presale_fund_collector

--- a/ico/tests/fixtures/presale.py
+++ b/ico/tests/fixtures/presale.py
@@ -52,7 +52,6 @@ def presale_fund_collector(chain, presale_freeze_ends_at, team_multisig) -> Cont
     ]
     tx = {
         "from": team_multisig,
-        "gas": 4000000
     }
     presale_fund_collector, hash = chain.provider.deploy_contract('PresaleFundCollector', deploy_args=args, deploy_transaction=tx)
     return presale_fund_collector

--- a/project.json
+++ b/project.json
@@ -277,8 +277,10 @@
             "metadata"
           ],
           "command_line_options": {
-            "allow_paths": "/",
-            "evm_version": "homestead"
+            "allow_paths": "/"
+          },
+          "stdin": {
+            "evmVersion": "homestead"
           }
         }
       },

--- a/project.json
+++ b/project.json
@@ -269,18 +269,30 @@
       "SolcAutoBackend": {
         "class": "populus.compilation.backends.SolcAutoBackend",
         "settings": {
-          "optimize": true,
-          "output_values": [
-            "abi",
-            "bin",
-            "bin-runtime",
-            "metadata"
-          ],
           "command_line_options": {
             "allow_paths": "/"
           },
           "stdin": {
-            "evmVersion": "homestead"
+            "output_values": [
+              "abi",
+              "bin",
+              "bin-runtime",
+              "metadata"
+            ],
+            "evmVersion": "homestead",
+            "optimizer": {
+              "enabled": true,
+              "runs": 500
+            },
+            "outputSelection": {
+              "*": {
+                "*": [
+                  "abi",
+                  "metadata",
+                  "evm"
+                 ]
+              }
+            }
           }
         }
       },

--- a/project.json
+++ b/project.json
@@ -7,16 +7,23 @@
       "contracts": {
         "backends": {
           "JSONFile": {
-            "$ref": "contracts.backends.JSONFile"
+            "class": "populus.contracts.backends.filesystem.JSONFileBackend",
+            "priority": 10,
+            "settings": {
+              "file_path": "./registrar.json"
+            }
           },
           "Memory": {
-            "$ref": "contracts.backends.Memory"
+            "class": "populus.contracts.backends.memory.MemoryBackend",
+            "priority": 50
           },
           "ProjectContracts": {
-            "$ref": "contracts.backends.ProjectContracts"
+            "class": "populus.contracts.backends.project.ProjectContractsBackend",
+            "priority": 20
           },
           "TestContracts": {
-            "$ref": "contracts.backends.TestContracts"
+            "class": "populus.contracts.backends.testing.TestContractsBackend",
+            "priority": 40
           }
         }
       },
@@ -32,7 +39,6 @@
         }
       }
     },
-
     "kovan": {
       "chain": {
         "class": "populus.chain.external.ExternalChain"
@@ -40,16 +46,11 @@
       "contracts": {
         "backends": {
           "JSONFile": {
-            "$ref": "contracts.backends.JSONFile"
-          },
-          "Memory": {
-            "$ref": "contracts.backends.Memory"
-          },
-          "ProjectContracts": {
-            "$ref": "contracts.backends.ProjectContracts"
-          },
-          "TestContracts": {
-            "$ref": "contracts.backends.TestContracts"
+            "class": "populus.contracts.backends.filesystem.JSONFileBackend",
+            "priority": 10,
+            "settings": {
+              "file_path": "./registrar.json"
+            }
           }
         }
       },
@@ -65,7 +66,6 @@
         }
       }
     },
-
     "local": {
       "chain": {
         "class": "populus.chain.geth.LocalGethChain",
@@ -75,17 +75,17 @@
       },
       "contracts": {
         "backends": {
-          "JSONFile": {
-            "$ref": "contracts.backends.JSONFile"
-          },
           "Memory": {
-            "$ref": "contracts.backends.Memory"
+            "class": "populus.contracts.backends.memory.MemoryBackend",
+            "priority": 50
           },
           "ProjectContracts": {
-            "$ref": "contracts.backends.ProjectContracts"
+            "class": "populus.contracts.backends.project.ProjectContractsBackend",
+            "priority": 20
           },
           "TestContracts": {
-            "$ref": "contracts.backends.TestContracts"
+            "class": "populus.contracts.backends.testing.TestContractsBackend",
+            "priority": 40
           }
         }
       },
@@ -101,24 +101,23 @@
         }
       }
     },
-
     "ganache": {
       "chain": {
         "class": "populus.chain.external.ExternalChain"
       },
       "contracts": {
         "backends": {
-          "JSONFile": {
-            "$ref": "contracts.backends.JSONFile"
-          },
           "Memory": {
-            "$ref": "contracts.backends.Memory"
+            "class": "populus.contracts.backends.memory.MemoryBackend",
+            "priority": 50
           },
           "ProjectContracts": {
-            "$ref": "contracts.backends.ProjectContracts"
+            "class": "populus.contracts.backends.project.ProjectContractsBackend",
+            "priority": 20
           },
           "TestContracts": {
-            "$ref": "contracts.backends.TestContracts"
+            "class": "populus.contracts.backends.testing.TestContractsBackend",
+            "priority": 40
           }
         }
       },
@@ -140,17 +139,17 @@
       },
       "contracts": {
         "backends": {
-          "JSONFile": {
-            "$ref": "contracts.backends.JSONFile"
-          },
           "Memory": {
-            "$ref": "contracts.backends.Memory"
+            "class": "populus.contracts.backends.memory.MemoryBackend",
+            "priority": 50
           },
           "ProjectContracts": {
-            "$ref": "contracts.backends.ProjectContracts"
+            "class": "populus.contracts.backends.project.ProjectContractsBackend",
+            "priority": 20
           },
           "TestContracts": {
-            "$ref": "contracts.backends.TestContracts"
+            "class": "populus.contracts.backends.testing.TestContractsBackend",
+            "priority": 40
           }
         }
       },
@@ -168,21 +167,21 @@
     },
     "temp": {
       "chain": {
-        "class": "populus.chain.geth.TemporaryGethChain",
-        "settings": {
-          "rpc_port": "8548"
-        }
+        "class": "populus.chain.geth.TemporaryGethChain"
       },
       "contracts": {
         "backends": {
           "Memory": {
-            "$ref": "contracts.backends.Memory"
+            "class": "populus.contracts.backends.memory.MemoryBackend",
+            "priority": 50
           },
           "ProjectContracts": {
-            "$ref": "contracts.backends.ProjectContracts"
+            "class": "populus.contracts.backends.project.ProjectContractsBackend",
+            "priority": 20
           },
           "TestContracts": {
-            "$ref": "contracts.backends.TestContracts"
+            "class": "populus.contracts.backends.testing.TestContractsBackend",
+            "priority": 40
           }
         }
       },
@@ -197,23 +196,33 @@
     },
     "tester": {
       "chain": {
-        "class": "populus.chain.tester.TesterChain"
+        "class": "populus.chain.tester.TesterChain",
+         "wait": {
+           "settings": {
+              "timeout": 10000
+           }
+         }
       },
       "contracts": {
         "backends": {
           "Memory": {
-            "$ref": "contracts.backends.Memory"
+            "class": "populus.contracts.backends.memory.MemoryBackend",
+            "priority": 50
           },
           "ProjectContracts": {
-            "$ref": "contracts.backends.ProjectContracts"
+            "class": "populus.contracts.backends.project.ProjectContractsBackend",
+            "priority": 20
           },
           "TestContracts": {
-            "$ref": "contracts.backends.TestContracts"
+            "class": "populus.contracts.backends.testing.TestContractsBackend",
+            "priority": 40
           }
         }
       },
       "web3": {
-        "$ref": "web3.Tester"
+        "provider": {
+          "class": "web3.providers.tester.EthereumTesterProvider"
+        }
       }
     },
     "testrpc": {
@@ -223,42 +232,53 @@
       "contracts": {
         "backends": {
           "Memory": {
-            "$ref": "contracts.backends.Memory"
+            "class": "populus.contracts.backends.memory.MemoryBackend",
+            "priority": 50
           },
           "ProjectContracts": {
-            "$ref": "contracts.backends.ProjectContracts"
+            "class": "populus.contracts.backends.project.ProjectContractsBackend",
+            "priority": 20
           },
           "TestContracts": {
-            "$ref": "contracts.backends.TestContracts"
+            "class": "populus.contracts.backends.testing.TestContractsBackend",
+            "priority": 40
           }
         }
       },
       "web3": {
-        "$ref": "web3.TestRPC"
+        "provider": {
+          "class": "web3.providers.tester.TestRPCProvider"
+        }
       }
     }
   },
   "compilation": {
     "backend": {
-      "$ref": "compilation.backends.SolcAutoBackend"
+      "class": "populus.compilation.backends.SolcStandardJSONBackend",
+      "settings": {
+        "optimize": true,
+        "output_values": [
+          "abi",
+          "bin",
+          "bin-runtime",
+          "metadata"
+        ]
+      }
     },
     "backends": {
       "SolcAutoBackend": {
         "class": "populus.compilation.backends.SolcAutoBackend",
         "settings": {
-          "stdin": {
-            "optimizer": {
-              "enabled": true,
-              "runs": 500
-            },
-            "outputSelection": {
-              "*": {
-                "*": ["abi", "metadata"]
-              }
-            }
-          },
+          "optimize": true,
+          "output_values": [
+            "abi",
+            "bin",
+            "bin-runtime",
+            "metadata"
+          ],
           "command_line_options": {
-            "allow_paths": "/"
+            "allow_paths": "/",
+            "evm_version": "homestead"
           }
         }
       },
@@ -277,23 +297,38 @@
       "SolcStandardJSON": {
         "class": "populus.compilation.backends.SolcStandardJSONBackend",
         "settings": {
-          "optimizer": {
-            "enabled": false,
-            "runs": 500
-          },
-          "outputSelection": {
-            "*": {
-              "*": ["abi", "metadata"]
+          "optimize": true,
+          "output_values": [
+            "abi",
+            "bin",
+            "bin-runtime",
+            "metadata"
+          ],
+          "stdin": {
+            "optimizer": {
+              "enabled": true,
+              "runs": 500
+            },
+            "outputSelection": {
+              "*": {
+                "*": [
+                  "abi",
+                  "metadata",
+                  "evm"
+                ]
+              }
             }
           },
-          "allow_paths": ["/"]
+          "command_line_options": {
+            "allow_paths": "/"
+          }
         }
       }
     },
-    "contracts_source_dirs": [
+    "contract_source_dirs": [
       "./contracts"
     ],
-    "import_remappings": []
+    "import_remappings": ["zeppelin=zeppelin"]
   },
   "contracts": {
     "backends": {
@@ -318,7 +353,7 @@
       }
     }
   },
-  "version": "6",
+  "version": "8",
   "web3": {
     "GethIPC": {
       "provider": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ click==6.7
 contextlib2==0.5.5
 eth-testrpc==1.3.0
 ethereum==1.6.1
-ethereum-abi-utils==0.4.0
-ethereum-utils==0.3.2
+ethereum-abi-utils==0.4.3
+ethereum-utils==0.5.0
 idna==2.5
 Jinja2==2.9.6
 json-rpc==1.10.3
@@ -17,10 +17,10 @@ jsonschema==2.6.0
 MarkupSafe==1.0
 pathtools==0.1.2
 pbkdf2==1.3
-populus==1.9.0
+-e git+https://github.com/voith/populus.git@ico-fixes#egg=populus
 py==1.4.34
 py-geth==1.9.0
-py-solc==1.4.0
+py-solc==3.1.0
 pycparser==2.18
 pycryptodome==3.4.6
 pyethash==0.1.27
@@ -30,7 +30,7 @@ pytest==3.2.0
 PyYAML==3.12
 repoze.lru==0.6
 requests==2.18.3
-rlp==0.5.1
+rlp==0.6.0
 ruamel.yaml==0.15.23
 scrypt==0.8.0
 secp256k1==0.13.2
@@ -39,5 +39,5 @@ toolz==0.8.2
 toposort==1.5
 urllib3==1.22
 watchdog==0.8.3
-web3==3.11.1
+web3==3.16.2
 Werkzeug==0.12.2

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ commands=flake8 ico
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/ico
-    TESTRPC_GAS_LIMIT = 6000000
 deps =
     -r{toxinidir}/requirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ commands=flake8 ico
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/ico
+    TESTRPC_GAS_LIMIT = 6000000
 deps =
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
### What was wrong?
The ico repository was not compatible with the latest version of `populus` and `solidity` 

### How was it fixed?
- submitted fixes in `py-solc` repository: https://github.com/ethereum/py-solc/pull/53, https://github.com/ethereum/py-solc/pull/55.
- Have added some [temporary fixes](https://github.com/ethereum/populus/compare/master...voith:ico-fixes?expand=1) in populus to show what needs to be done to get the test suite green. I need to investigate a little about the best way to sub mit those fixes. Fixes in populus needed fixing the `verify_contract_bytecode` method and introducing `evmVersion` in populus
-  updated solidity version in `.travis.yml` to `0.4.24`.
- updated `requirements.txt` to pin the latest dependencies needed(There are some dependency issues with populus. However I fixed them by pinning them in `requirements.txt`)
- `populus.json` was ported to the new `project.json`
- `evm_version` was set `homestead`. Read https://medium.com/@chris_77367/explaining-unexpected-reverts-starting-with-solidity-0-4-22-3ada6e82308c for more details.
- Had to increase gas limit in tests `TESTRPC_GAS_LIMIT = 6000000` as one test needs more gas. This seems wrong but I think this could be fixed. My suspect is populus which is not optimizing the bytecode as specified in `populus.json`. I verified this from the bytecode that was generated in `.cache`.


### checklist before merging

- [ ]  Make sure that `populus.json` has been properly translated to `project.json`.
- [ ] Ask @miohtama and @petri If this needs more manual testing before merging. `TokenMarketNet` might have dependent code based on this change. So I'd need some help with integration testing.
- [ ] submit fixes from my populus fork to the main repository and on merging the fixes make sure ico is pinned with a new release of populus.