### PR TITLE
monkey patch populus code to make timeout configurable

### DIFF
--- a/ico/cmd/deploycontracts.py
+++ b/ico/cmd/deploycontracts.py
@@ -1,16 +1,17 @@
 """Deploy crowdsale and all related contracts contract."""
 
 import click
-from populus import Project
 
 from ico.deploy import deploy_crowdsale_from_file
+from ico.project import IcoProject
 
 
 @click.command()
 @click.option('--deployment-name', nargs=1, default="mainnet", help='Project section id inside the YAML file. The topmost YAML key. Example YAML files use "mainnet" or "kovan".', required=True)
 @click.option('--deployment-file', nargs=1, help='Deployment script YAML .yml file to process', required=True)
 @click.option('--address', nargs=1, help='Your Ethereum account that is the owner of deployment and pays the gas cost. This account must exist on Ethereum node we connect to. Connection parameteres, port and IP, are defined in populus.json.', required=True)
-def main(deployment_file, deployment_name, address):
+@click.option('--timeout', nargs=1, default=1000, help='Timeout for contract to get deployed', required=False)
+def main(deployment_file, deployment_name, address, timeout):
     """Makes a scripted multiple contracts deployed based on a YAML file.
 
     Reads the chain configuration information from populus.json.
@@ -25,7 +26,7 @@ def main(deployment_file, deployment_name, address):
     * https://github.com/TokenMarketNet/ico/blob/master/crowdsales/example.yml
     """
 
-    project = Project()
+    project = IcoProject(timeout=timeout)
     deploy_crowdsale_from_file(project, deployment_file, deployment_name, address)
     print("All done! Enjoy your decentralized future.")
 

--- a/ico/project.py
+++ b/ico/project.py
@@ -1,0 +1,41 @@
+import ico
+from populus import Project
+from populus.config.chain import ChainConfig
+from populus.wait import Wait
+
+
+class IcoChainConfig(ChainConfig):
+    timeout = 1000
+
+    def get_chain(self, *args, **kwargs):
+        class IcoChain(self.chain_class):
+            @property
+            def wait(self):
+                return Wait(self.web3, timeout=IcoChainConfig.timeout)
+
+        self.chain_class = IcoChain
+        setattr(ico.project, 'IcoChain', IcoChain)
+        return super(IcoChainConfig, self).get_chain(*args, **kwargs)
+
+
+class IcoProject(Project):
+    # FIXME: Temporary fix to increase timeout in populus
+    # Remove this code once
+    # https://github.com/ethereum/populus/pull/464 gets merged
+
+    def __init__(self, *args, **kwargs):
+        self.timeout = kwargs.pop('timeout', 1000)
+        super(IcoProject, self).__init__(*args, **kwargs)
+
+    def get_chain_config(self, chain_name):
+        chain_config_key = 'chains.{chain_name}'.format(chain_name=chain_name)
+        IcoChainConfig.timeout = self.timeout
+        if chain_config_key in self.config:
+            return self.config.get_config(chain_config_key, config_class=IcoChainConfig)
+        else:
+            raise KeyError(
+                "Unknown chain: {0!r} - Must be one of {1!r}".format(
+                    chain_name,
+                    sorted(self.config.get('chains', {}).keys()),
+                )
+            )

--- a/ico/tests/tools/test_ico_project.py
+++ b/ico/tests/tools/test_ico_project.py
@@ -1,0 +1,10 @@
+import sys
+
+from ico.project import IcoProject
+
+
+def test_ico_project_timeout():
+    timeout = sys.maxsize
+    project = IcoProject(timeout=timeout)
+    with project.get_chain('tester') as chain:
+        assert chain.wait.timeout == timeout


### PR DESCRIPTION
created a new `IcoProject`class  which subclasses `populus.Project`  to make `wait.timeout` configurable.
I have introduced a new command line parameter `timeout` for `deploycontracts.py`.
Also, I made the default value large enough so that users don't complain.