### PR TITLE
RestrictedTransferAgent: Changing KYC to be public

### DIFF
--- a/contracts/security-token/RestrictedTransferAgent.sol
+++ b/contracts/security-token/RestrictedTransferAgent.sol
@@ -5,7 +5,7 @@ import "./KYCInterface.sol";
 import "./SecurityTransferAgentInterface.sol";
 
 contract RestrictedTransferAgent is SecurityTransferAgent, KYCAttributes {
-  KYCInterface KYC;
+  KYCInterface public KYC;
 
   function RestrictedTransferAgent(KYCInterface _KYC) {
     KYC = _KYC;


### PR DESCRIPTION
KYC wasn't public for some reason, now it's is, so it's also visible on
tools such as Etherscan.