### PR TITLE
InvestorInteractionContract: Voting cannot be gamed anymore

### DIFF
--- a/contracts/security-token/tests/InvestorInteractionContract.sol
+++ b/contracts/security-token/tests/InvestorInteractionContract.sol
@@ -35,6 +35,8 @@ contract InvestorInteractionContract is BogusAnnouncement, CheckpointToken, ERC8
     KYC = _KYC;
 
     for(uint i=0; i<_options.length; i++) {
+      require(_options[i] != 0);
+
       address optionAddress = address(100 + i);
       options[optionAddress] = _options[i];
 
@@ -48,7 +50,7 @@ contract InvestorInteractionContract is BogusAnnouncement, CheckpointToken, ERC8
 
   function importInvestor(address investor) public {
     // Anyone can invoke this for failsafe reasons
-
+    require(options[investor] == 0);
     require(balanceImported[investor] == false);
 
     uint256 value = token.balanceAt(investor, checkpointID);


### PR DESCRIPTION
We are using for internal vote counting addresses starting from 0x64 upwards.
This is to provide extreme compatibility with all the wallets: bare minimum is,
an ability to transfer EIP-20 tokens.

However, if someone would transfer some SecurityTokens to 0x64 or related
addresses, they could nullify the votes by calling importInvestor(0x64).

This is now prevented.

Test will be amended once we have a conflict-free test_security_token.py.