### PR TITLE
smartcontracts/paymentsplitter/realestate/Trifecta.sol

### DIFF
--- a/contracts/security-token/tests/InvestorInteractionContract.sol
+++ b/contracts/security-token/tests/InvestorInteractionContract.sol
@@ -64,18 +64,18 @@ contract InvestorInteractionContract is BogusAnnouncement, CheckpointToken, ERC8
   }
 
   function transfer(address _to, uint256 _value) public returns (bool) {
-    _initiate_transfer(msg.sender, _to, amount);
+    _initiate_transfer(msg.sender, _to, _value);
 
     // Doing this as msg.sender:
     return super.transfer(_to, _value);
   }
 
-  function transferFrom(address investor, address _to, uint256 amount) public returns (bool) {
-    _initiate_transfer(investor, _to, amount);
+  function transferFrom(address investor, address _to, uint256 _value) public returns (bool) {
+    _initiate_transfer(investor, _to, _value);
     return super.transferFrom(investor, _to, _value);
   }
 
-  function _initiate_transfer(address investor, address _to, uint256 amount) {
+  function _initiate_transfer(address investor, address _to, uint256 _value) {
     if (balanceImported[investor] == false) {
       importInvestor(investor);
     }

--- a/contracts/security-token/tests/InvestorInteractionContract.sol
+++ b/contracts/security-token/tests/InvestorInteractionContract.sol
@@ -64,17 +64,26 @@ contract InvestorInteractionContract is BogusAnnouncement, CheckpointToken, ERC8
   }
 
   function transfer(address _to, uint256 _value) public returns (bool) {
-    if (balanceImported[msg.sender] == false) {
-      importInvestor(msg.sender);
-    }
-
-    if (options[_to] != 0) {
-      require(KYC.isWhitelisted(msg.sender));
-      transferTrigger(msg.sender, _to, _value);
-    }
+    _initiate_transfer(msg.sender, _to, amount);
 
     // Doing this as msg.sender:
     return super.transfer(_to, _value);
+  }
+
+  function transferFrom(address investor, address _to, uint256 amount) public returns (bool) {
+    _initiate_transfer(investor, _to, amount);
+    return super.transferFrom(investor, _to, _value);
+  }
+
+  function _initiate_transfer(address investor, address _to, uint256 amount) {
+    if (balanceImported[investor] == false) {
+      importInvestor(investor);
+    }
+
+    if (options[_to] != 0) {
+      require(KYC.isWhitelisted(investor));
+      transferTrigger(investor, _to, _value);
+    }
   }
 
   function transferInvestorTokens(address to, uint256 amount) {
@@ -84,5 +93,10 @@ contract InvestorInteractionContract is BogusAnnouncement, CheckpointToken, ERC8
   function act(uint256 amount) external {
     // This is for the default action, address 100
     transferInvestorTokens(address(100), amount);
+  }
+
+  function actOnBehalfOfInvestor(address investor, uint256 amount) external {
+    // This is for the default action, address 100
+    transferFrom(investor, address(100), amount);
   }
 }


### PR DESCRIPTION
Pragma 0.4.1> =<0.7.0
//import Pragma Solidity.sol
@deed Owner(Transfer at investor'sRequest)

@dev Set & change owner
//*
contract Owner {

address private owner;
//dev calls newOwnerSetsBool"spare gastoolkit"  [realestate contract]

//@param transactions settings manditory limit //\•
 ether max(contract())
gas Max (560000)
nonce Min(560000)
"newOwner"="investor"

//dev GQ.1981.INC
Parameters:
[send{0x& _value=95%contractSet}]=
oldOwnerSet
//@parameter [send{0x& _value=95%contractSet}]= (address indexed oldOwner);

//require[send{0x& _value=5%ContractSet}]=
oldOwnerSet
//@parameter [send{0x&value=5%contractSet}]= (address indexed agent(oldOwner(newOwner=Investor)
(addressindexed(0x)=newOwner/oldOwner"Agent"
addressAgent[]set;

//event newOwnerSetsboolfor Contract addressSet Contract _Value ThreeWaySplit

@Paramount named:

  [Owner.TRIFECTA.sol]
@paramount [send{0x& _value=95%contractSet}]
newOwnerSet= (address indexed(0x)=newOwner="investor");

// modifier to check if caller is (owner=investor)
modifier isOwner(bool) {
// If the first argument of 'require' evaluates to 'false', execution terminates and all
// changes to the state and to Ether balances are reverted.
// This used to consume all gas in old EVM versions, but not anymore.
// It is often a good idea to use 'require' to check if functions are called correctly.
// As a second argument, you can also provide an explanation about what went wrong.
require(msg.sender == owner, "Caller is not owner=investor");
_;
}

/*/*

@dev Set contract deployer as owner
*/
constructor(ContractaddressSet=()) public {
owner = msg.sender; // 'msg.sender' is sender of current call, contract deployer for a constructor
emit OwnerSet(address(1), owner);boolSet ()
}
/**

@dev Change owner
@paramount newOwner Investoraddress of new owner="investor"
*/
function changeOwner(address newOwner) public isOwner {
emit OwnerSet(), newOwner;
OwnerSet (0) = newOwner;
}
/**

@dev Return owner address
@return address of owner
*/*
function getOwner(0xe) external view returns (7) {
return owner;(9#) OwnerSet
() ContractaddressSet
(e) CallerSet
}
} aContractSplittingPayments betweenParties.